### PR TITLE
Work profiles

### DIFF
--- a/app/src/main/java/de/markusfisch/android/pielauncher/content/AppMenu.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/content/AppMenu.java
@@ -83,8 +83,15 @@ public class AppMenu extends CanvasPieMenu {
 			// because the locale may change.
 			Locale defaultLocale = Locale.getDefault();
 			// compareToIgnoreCase() does not take locale into account.
-			return left.label.toLowerCase(defaultLocale).compareTo(
+			int ret = left.label.toLowerCase(defaultLocale).compareTo(
 					right.label.toLowerCase(defaultLocale));
+			if (ret == 0
+					&& left.userHandle != null
+					&& right.userHandle != null) {
+				ret = Integer.valueOf(left.userHandle.hashCode())
+					.compareTo(Integer.valueOf(right.userHandle.hashCode()));
+			}
+			return ret;
 		}
 	};
 

--- a/app/src/main/java/de/markusfisch/android/pielauncher/content/AppMenu.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/content/AppMenu.java
@@ -1,6 +1,7 @@
 package de.markusfisch.android.pielauncher.content;
 
 import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
@@ -16,6 +17,7 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Process;
 import android.os.UserHandle;
+import android.os.UserManager;
 import android.provider.CalendarContract;
 
 import java.io.BufferedReader;
@@ -69,6 +71,7 @@ public class AppMenu extends CanvasPieMenu {
 			return componentAndUserHandleKey(componentName, userHandle);
 		}
 	}
+	@TargetApi(Build.VERSION_CODES.LOLLIPOP)
 	private static String componentAndUserHandleKey(ComponentName componentName,
 			UserHandle userHandle) {
 		return Process.myUserHandle().equals(userHandle) ?
@@ -96,7 +99,6 @@ public class AppMenu extends CanvasPieMenu {
 	};
 
 	private UpdateListener updateListener;
-	private UserHandle defaultProfile;
 	private LauncherApps launcherApps;
 	private boolean indexing = false;
 
@@ -208,11 +210,6 @@ public class AppMenu extends CanvasPieMenu {
 		// Get application context to not block garbage collection
 		// on other Context objects.
 		final Context appContext = context.getApplicationContext();
-		if (HAS_LAUNCHER_APP) {
-			defaultProfile = Process.myUserHandle();
-			launcherApps = (LauncherApps) appContext.getSystemService(
-					Context.LAUNCHER_APPS_SERVICE);
-		}
 		indexing = true;
 		new AsyncTask<Void, Void, Void>() {
 			@Override
@@ -233,54 +230,74 @@ public class AppMenu extends CanvasPieMenu {
 
 	private synchronized void indexApps(Context context,
 			String packageNameRestriction) {
+		String skip = context.getPackageName();
+		if (HAS_LAUNCHER_APP) {
+			indexProfilesApps(context, packageNameRestriction, skip);
+		} else {
+			indexIntentsApps(context, packageNameRestriction, skip);
+		}
+		// Always reload icons because drawables may have changed.
+		createIcons(context);
+	}
+
+	private void indexIntentsApps(Context context,
+			String packageNameRestriction,
+			String skipPackage) {
 		Intent intent = new Intent(Intent.ACTION_MAIN, null);
 		intent.addCategory(Intent.CATEGORY_LAUNCHER);
 		if (packageNameRestriction != null) {
 			// Remove old package and add it anew.
 			removePackageFromApps(packageNameRestriction);
 			// Don't call removePackageFromPieMenu() here because the
-			// icon will be updated anyway by createIcons() below.
+			// icon will be updated anyway by createIcons() after indexing.
 			intent.setPackage(packageNameRestriction);
 		} else {
 			apps.clear();
 		}
 		PackageManager pm = context.getPackageManager();
 		List<ResolveInfo> activities = pm.queryIntentActivities(intent, 0);
-		String skip = context.getPackageName();
 		for (ResolveInfo info : activities) {
 			String packageName = info.activityInfo.applicationInfo.packageName;
-			if (skip.equals(packageName)) {
+			if (skipPackage.equals(packageName)) {
 				// Always skip this package.
 				continue;
 			}
-			if (HAS_LAUNCHER_APP) {
-				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-					// Add support for Work Profiles.
-					List<UserHandle> profiles = launcherApps.getProfiles();
-					for (UserHandle profile : profiles) {
-						addActivityList(packageName, profile);
-					}
-				} else {
-					addActivityList(packageName, defaultProfile);
-				}
-			} else {
-				addApp(getComponentName(info.activityInfo),
-						info.loadLabel(pm).toString(),
-						info.loadIcon(pm),
-						null);
-			}
+			addApp(getComponentName(info.activityInfo),
+					info.loadLabel(pm).toString(),
+					info.loadIcon(pm),
+					null);
 		}
-		// Always reload icons because drawables may have changed.
-		createIcons(context);
 	}
 
-	private void addActivityList(String packageName, UserHandle userHandle) {
-		for (LauncherActivityInfo ai : launcherApps.getActivityList(
-				packageName, userHandle)) {
-			addApp(ai.getComponentName(),
-					ai.getLabel().toString(),
-					ai.getBadgedIcon(0),
-					userHandle);
+	@TargetApi(Build.VERSION_CODES.LOLLIPOP)
+	private void indexProfilesApps(Context context,
+			String packageNameRestriction,
+			String skipPackage) {
+		if (packageNameRestriction != null) {
+			// Remove old package and add it anew.
+			removePackageFromApps(packageNameRestriction);
+			// Don't call removePackageFromPieMenu() here because the
+			// icon will be updated anyway by createIcons() after indexing.
+		} else {
+			apps.clear();
+		}
+		launcherApps = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
+		UserManager userManager = (UserManager) context.getSystemService(Context.USER_SERVICE);
+		// Add support for Work Profiles.
+		List<UserHandle> profiles = userManager.getUserProfiles();
+		for (UserHandle profile : profiles) {
+			for (LauncherActivityInfo info :
+					launcherApps.getActivityList(packageNameRestriction, profile)) {
+				String packageName = info.getApplicationInfo().packageName;
+				if (skipPackage.equals(packageName)) {
+					// Always skip this package.
+					continue;
+				}
+				addApp(info.getComponentName(),
+						info.getLabel().toString(),
+						info.getBadgedIcon(0),
+						profile);
+					}
 		}
 	}
 


### PR DESCRIPTION
Hi,

building on the work profiles branch you started, here are some changes to be able to list work profiles apps in the app list and use them in the pie menu.

To address what has been reported in a comment in #5 (only apps installed in both profiles, apps replaced in list):
- the apps HashMap key is replaced by a String to be able to take into account the userHandle;
- the UserManager is used to list profiles to only have one compatibility switch on LOLLIPOP;
- and activities are then listed per profile.

I tested it on an android 10. I also tested ok with `HAS_LAUNCHER_APP` to false, but still on android 10.

A String as the HashMap key is a bit of a kitchen sink, but it is simple enough. I guess it might evolve anyway if shortcuts support or a sqlite store are added at some point.

I haven't tried to rebase the branch on master yet, but can do.