### PR TITLE
Work profiles: packages events

### DIFF
--- a/app/src/main/java/de/markusfisch/android/pielauncher/app/PieLauncherApp.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/app/PieLauncherApp.java
@@ -56,19 +56,19 @@ public class PieLauncherApp extends Application {
 			@Override
 			public void onPackageAdded(String packageName,
 					UserHandle user) {
-				appMenu.indexAppsAsync(PieLauncherApp.this, packageName);
+				appMenu.indexAppsAsync(PieLauncherApp.this, packageName, user);
 			}
 
 			@Override
 			public void onPackageChanged(String packageName,
 					UserHandle user) {
-				appMenu.indexAppsAsync(PieLauncherApp.this, packageName);
+				appMenu.indexAppsAsync(PieLauncherApp.this, packageName, user);
 			}
 
 			@Override
 			public void onPackageRemoved(String packageName,
 					UserHandle user) {
-				appMenu.removePackageAsync(packageName);
+				appMenu.removePackageAsync(packageName, user);
 			}
 
 			@Override

--- a/app/src/main/java/de/markusfisch/android/pielauncher/app/PieLauncherApp.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/app/PieLauncherApp.java
@@ -10,9 +10,12 @@ import android.os.UserHandle;
 
 import de.markusfisch.android.pielauncher.content.AppMenu;
 import de.markusfisch.android.pielauncher.preference.Preferences;
+import de.markusfisch.android.pielauncher.receiver.LocaleEventReceiver;
 import de.markusfisch.android.pielauncher.receiver.PackageEventReceiver;
 
 public class PieLauncherApp extends Application {
+	private static final LocaleEventReceiver localeEventReceiver =
+			new LocaleEventReceiver();
 	private static final PackageEventReceiver packageEventReceiver =
 			new PackageEventReceiver();
 
@@ -24,19 +27,23 @@ public class PieLauncherApp extends Application {
 		super.onCreate();
 		prefs.init(this);
 
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
-				Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-			// Because package broadcasts stop mysteriously working after
-			// a while on Android Nougat only.
+		registerLocaleEventReceiver();
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+			// Use LauncherApps.Callback for packages events
 			registerCallback();
 		} else {
 			registerPackageEventReceiver();
 		}
 	}
 
-	private void registerPackageEventReceiver() {
+	private void registerLocaleEventReceiver() {
 		IntentFilter filter = new IntentFilter();
 		filter.addAction(Intent.ACTION_LOCALE_CHANGED);
+		registerReceiver(localeEventReceiver, filter);
+	}
+
+	private void registerPackageEventReceiver() {
+		IntentFilter filter = new IntentFilter();
 		filter.addAction(Intent.ACTION_PACKAGE_ADDED);
 		filter.addAction(Intent.ACTION_PACKAGE_REMOVED);
 		filter.addAction(Intent.ACTION_PACKAGE_CHANGED);

--- a/app/src/main/java/de/markusfisch/android/pielauncher/app/PieLauncherApp.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/app/PieLauncherApp.java
@@ -11,11 +11,14 @@ import android.os.UserHandle;
 import de.markusfisch.android.pielauncher.content.AppMenu;
 import de.markusfisch.android.pielauncher.preference.Preferences;
 import de.markusfisch.android.pielauncher.receiver.LocaleEventReceiver;
+import de.markusfisch.android.pielauncher.receiver.ManagedProfileEventReceiver;
 import de.markusfisch.android.pielauncher.receiver.PackageEventReceiver;
 
 public class PieLauncherApp extends Application {
 	private static final LocaleEventReceiver localeEventReceiver =
 			new LocaleEventReceiver();
+	private static final ManagedProfileEventReceiver
+		managedProfileEventReceiver = new ManagedProfileEventReceiver();
 	private static final PackageEventReceiver packageEventReceiver =
 			new PackageEventReceiver();
 
@@ -31,6 +34,7 @@ public class PieLauncherApp extends Application {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
 			// Use LauncherApps.Callback for packages events
 			registerCallback();
+			registerManagedEventReceiver();
 		} else {
 			registerPackageEventReceiver();
 		}
@@ -40,6 +44,14 @@ public class PieLauncherApp extends Application {
 		IntentFilter filter = new IntentFilter();
 		filter.addAction(Intent.ACTION_LOCALE_CHANGED);
 		registerReceiver(localeEventReceiver, filter);
+	}
+
+	@TargetApi(Build.VERSION_CODES.LOLLIPOP)
+	private void registerManagedEventReceiver() {
+		IntentFilter filter = new IntentFilter();
+		filter.addAction(Intent.ACTION_MANAGED_PROFILE_ADDED);
+		filter.addAction(Intent.ACTION_MANAGED_PROFILE_REMOVED);
+		registerReceiver(managedProfileEventReceiver, filter);
 	}
 
 	private void registerPackageEventReceiver() {

--- a/app/src/main/java/de/markusfisch/android/pielauncher/content/AppMenu.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/content/AppMenu.java
@@ -276,8 +276,12 @@ public class AppMenu extends CanvasPieMenu {
 		}
 		launcherApps = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
 		UserManager userManager = (UserManager) context.getSystemService(Context.USER_SERVICE);
-		// Add support for Work Profiles.
-		List<UserHandle> profiles = userManager.getUserProfiles();
+		List<UserHandle> profiles =
+			packageNameRestriction != null && userHandleRestriction != null
+			? Collections.singletonList(userHandleRestriction)
+			: userManager.getUserProfiles();
+			// if packageNameRestriction == null and userHandleRestriction != null
+			// apps was cleared and all profiles will be indexed
 		for (UserHandle profile : profiles) {
 			for (LauncherActivityInfo info :
 					launcherApps.getActivityList(packageNameRestriction, profile)) {

--- a/app/src/main/java/de/markusfisch/android/pielauncher/content/AppMenu.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/content/AppMenu.java
@@ -94,11 +94,16 @@ public class AppMenu extends CanvasPieMenu {
 
 	public void launchApp(Context context, AppIcon icon) {
 		if (HAS_LAUNCHER_APP) {
-			launcherApps.startMainActivity(
-					icon.componentName,
-					icon.userHandle,
-					icon.rect,
-					null);
+			if (launcherApps.isActivityEnabled(icon.componentName,
+						icon.userHandle)) {
+				launcherApps.startMainActivity(
+						icon.componentName,
+						icon.userHandle,
+						icon.rect,
+						null);
+			} else {
+				return;
+			}
 		} else {
 			PackageManager pm = context.getPackageManager();
 			Intent intent;

--- a/app/src/main/java/de/markusfisch/android/pielauncher/content/AppMenu.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/content/AppMenu.java
@@ -110,6 +110,23 @@ public class AppMenu extends CanvasPieMenu {
 		}
 	}
 
+	public void launchAppInfo(Context context, AppIcon icon) {
+		if (HAS_LAUNCHER_APP) {
+			launcherApps.startAppDetailsActivity(
+					icon.componentName,
+					icon.userHandle,
+					icon.rect,
+					null);
+		} else {
+			Intent intent = new Intent(
+					android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+			intent.addCategory(Intent.CATEGORY_DEFAULT);
+			intent.setData(Uri.parse("package:"
+						+ icon.componentName.getPackageName()));
+			context.startActivity(intent);
+		}
+	}
+
 	public void setUpdateListener(UpdateListener listener) {
 		updateListener = listener;
 	}

--- a/app/src/main/java/de/markusfisch/android/pielauncher/receiver/LocaleEventReceiver.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/receiver/LocaleEventReceiver.java
@@ -1,0 +1,20 @@
+package de.markusfisch.android.pielauncher.receiver;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+import de.markusfisch.android.pielauncher.app.PieLauncherApp;
+
+public class LocaleEventReceiver extends BroadcastReceiver {
+	@Override
+	public void onReceive(Context context, Intent intent) {
+		if (intent == null) {
+			return;
+		}
+		String action = intent.getAction();
+		if (Intent.ACTION_LOCALE_CHANGED.equals(action)) {
+			PieLauncherApp.appMenu.indexAppsAsync(context);
+		}
+	}
+}

--- a/app/src/main/java/de/markusfisch/android/pielauncher/receiver/ManagedProfileEventReceiver.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/receiver/ManagedProfileEventReceiver.java
@@ -1,0 +1,33 @@
+package de.markusfisch.android.pielauncher.receiver;
+
+import android.annotation.TargetApi;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+
+import de.markusfisch.android.pielauncher.app.PieLauncherApp;
+
+@TargetApi(Build.VERSION_CODES.LOLLIPOP)
+public class ManagedProfileEventReceiver extends BroadcastReceiver {
+	@Override
+	public void onReceive(Context context, Intent intent) {
+		if (intent == null) {
+			return;
+		}
+		String action = intent.getAction();
+		if (Intent.ACTION_MANAGED_PROFILE_ADDED.equals(action)
+				|| Intent.ACTION_MANAGED_PROFILE_REMOVED.equals(action)) {
+			PieLauncherApp.appMenu.indexAppsAsync(context);
+		}
+		// Ignore:
+		// - ACTION_MANAGED_PROFILE_AVAILABLE
+		// - ACTION_MANAGED_PROFILE_UNAVAILABLE
+		// - ACTION_MANAGED_PROFILE_UNLOCKED
+		// added in API level 24.
+		// When the managed profile is unavailable, trying to launch an app
+		// should propose to activate the profile and then launch the app (can
+		// take time). App icons can then be kept in the app list and pie menu
+		// all the time.
+	}
+}

--- a/app/src/main/java/de/markusfisch/android/pielauncher/receiver/PackageEventReceiver.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/receiver/PackageEventReceiver.java
@@ -26,12 +26,12 @@ public class PackageEventReceiver extends BroadcastReceiver {
 		if (Intent.ACTION_PACKAGE_ADDED.equals(action) ||
 				// Sent when a component of a package changed.
 				Intent.ACTION_PACKAGE_CHANGED.equals(action)) {
-			PieLauncherApp.appMenu.indexAppsAsync(context, packageName);
+			PieLauncherApp.appMenu.indexAppsAsync(context, packageName, null);
 		} else if (Intent.ACTION_PACKAGE_REMOVED.equals(action) &&
 				// Skip ACTION_PACKAGE_REMOVED when replacing because it
 				// will be immediately followed by ACTION_PACKAGE_ADDED.
 				!intent.getBooleanExtra(Intent.EXTRA_REPLACING, false)) {
-			PieLauncherApp.appMenu.removePackageAsync(packageName);
+			PieLauncherApp.appMenu.removePackageAsync(packageName, null);
 		}
 	}
 }

--- a/app/src/main/java/de/markusfisch/android/pielauncher/receiver/PackageEventReceiver.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/receiver/PackageEventReceiver.java
@@ -14,10 +14,6 @@ public class PackageEventReceiver extends BroadcastReceiver {
 			return;
 		}
 		String action = intent.getAction();
-		if (Intent.ACTION_LOCALE_CHANGED.equals(action)) {
-			PieLauncherApp.appMenu.indexAppsAsync(context);
-			return;
-		}
 		Uri data = intent.getData();
 		if (data == null) {
 			return;

--- a/app/src/main/java/de/markusfisch/android/pielauncher/widget/AppPieView.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/widget/AppPieView.java
@@ -734,8 +734,8 @@ public class AppPieView extends View {
 			ripple.set(touch);
 			if (grabbedIcon != null) {
 				rollback();
-				startAppInfo(((AppMenu.AppIcon) grabbedIcon)
-						.componentName.getPackageName());
+				PieLauncherApp.appMenu.launchAppInfo(context,
+						(AppMenu.AppIcon) grabbedIcon);
 			}
 			successful = true;
 		} else if (iconDoneRect.contains(touch.x, touch.y)) {
@@ -781,14 +781,6 @@ public class AppPieView extends View {
 			}
 		}
 		return true;
-	}
-
-	private void startAppInfo(String packageName) {
-		Intent intent = new Intent(
-				Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
-		intent.addCategory(Intent.CATEGORY_DEFAULT);
-		intent.setData(Uri.parse("package:" + packageName));
-		getContext().startActivity(intent);
 	}
 
 	private void setCenter(Point point) {


### PR DESCRIPTION
Use UserHandle when handling packages events and removing packages.

Use LauncherApps.Callback for all versions above Lollipop. It allows to get the UserHandle through the callbacks. Also split the PackageEventReceiver to have locale events in both cases, and add a ManagedProfilesEventReceiver to index apps when a profile is added or removed. I guess it could be simpler than having three receivers registered, maybe.

The default menu creation can still pick up apps from a work profile because it is based on the package name only. I think the structure could be changed similarly to a Package+User or Component+User (or Intent…) key for the HashMap, but I don't know what could be a good course of action.
