### PR TITLE
Add a "Change Orientation" button

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,7 +26,8 @@
 			android:taskAffinity=""
 			android:excludeFromRecents="true"
 			android:exported="true"
-			android:theme="@style/HomeTheme">
+			android:theme="@style/HomeTheme"
+			android:configChanges="orientation">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN"/>
 				<category android:name="android.intent.category.LAUNCHER"/>

--- a/app/src/main/java/de/markusfisch/android/pielauncher/activity/HomeActivity.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/activity/HomeActivity.java
@@ -66,10 +66,12 @@ public class HomeActivity extends Activity {
 		// Restrict to current orientation, whatever that is.
 		// Makes it possible to use it on tablets in landscape and
 		// in portrait for phones. Should become a choice at some point.
-		setRequestedOrientation(
-				Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2
-						? ActivityInfo.SCREEN_ORIENTATION_LOCKED
-						: ActivityInfo.SCREEN_ORIENTATION_NOSENSOR);
+
+		final int defaultOrientation = Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2
+				? ActivityInfo.SCREEN_ORIENTATION_LOCKED
+				: ActivityInfo.SCREEN_ORIENTATION_NOSENSOR;
+
+		setRequestedOrientation(PieLauncherApp.prefs.getOrientation(defaultOrientation));
 
 		kb = new SoftKeyboard(this);
 		gestureDetector = new GestureDetector(this, new FlingListener(

--- a/app/src/main/java/de/markusfisch/android/pielauncher/preference/Preferences.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/preference/Preferences.java
@@ -6,6 +6,7 @@ import android.preference.PreferenceManager;
 
 public class Preferences {
 	private static final String RADIUS = "radius";
+	private static final String ORIENTATION = "orientation";
 
 	private SharedPreferences preferences;
 
@@ -20,6 +21,16 @@ public class Preferences {
 		return preferences != null
 				? preferences.getInt(RADIUS, preset)
 				: preset;
+	}
+
+	public int getOrientation(int preset) {
+		return preferences != null
+				? preferences.getInt(ORIENTATION, preset)
+				: preset;
+	}
+
+	public void setOrientation(int orientation) {
+		apply(ORIENTATION, orientation);
 	}
 
 	public void setRadius(int radius) {

--- a/app/src/main/java/de/markusfisch/android/pielauncher/widget/AppPieView.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/widget/AppPieView.java
@@ -3,6 +3,7 @@ package de.markusfisch.android.pielauncher.widget;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
+import android.content.pm.ActivityInfo;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -77,6 +78,10 @@ public class AppPieView extends View {
 	private final Bitmap iconInfo;
 	private final Rect iconDoneRect = new Rect();
 	private final Bitmap iconDone;
+
+	private final Rect iconRotateRect = new Rect();
+	private final Bitmap iconRotate;
+
 	private final Bitmap iconLaunchFirst;
 	private final String numberOfIconsTip;
 	private final String dragToOrderTip;
@@ -145,6 +150,7 @@ public class AppPieView extends View {
 		iconRemove = getBitmapFromDrawable(res, R.drawable.ic_remove);
 		iconInfo = getBitmapFromDrawable(res, R.drawable.ic_info);
 		iconDone = getBitmapFromDrawable(res, R.drawable.ic_done);
+		iconRotate = getBitmapFromDrawable(res, R.drawable.ic_rotation);
 		iconLaunchFirst = getBitmapFromDrawable(res,
 				R.drawable.ic_launch_first);
 		iconLaunchFirstHalf = iconLaunchFirst.getWidth() >> 1;
@@ -582,8 +588,8 @@ public class AppPieView extends View {
 	}
 
 	private void layoutEditorControls(boolean portrait) {
-		Bitmap[] icons = new Bitmap[]{iconAdd, iconRemove, iconInfo, iconDone};
-		Rect[] rects = new Rect[]{iconAddRect, iconRemoveRect, iconInfoRect,
+		Bitmap[] icons = new Bitmap[]{iconAdd, iconRemove, iconRotate, iconInfo, iconDone};
+		Rect[] rects = new Rect[]{iconAddRect, iconRemoveRect, iconRotateRect, iconInfoRect,
 				iconDoneRect};
 		int length = icons.length;
 		int totalWidth = 0;
@@ -747,6 +753,17 @@ public class AppPieView extends View {
 				endEditMode();
 			}
 			successful = true;
+		} else if (iconRotateRect.contains(touch.x, touch.y)) {
+			boolean isPortrait = viewHeight > viewWidth;
+			int newOrientation = isPortrait
+							? ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+							: ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
+			PieLauncherApp.prefs.setOrientation(newOrientation);
+			// Make an attempt to apply new orientation if possible.
+			if(getContext() instanceof Activity) {
+				((Activity) getContext()).setRequestedOrientation(newOrientation);
+			}
+			successful = true;
 		}
 		grabbedIcon = null;
 		PieLauncherApp.appMenu.updateSmoothing();
@@ -867,6 +884,7 @@ public class AppPieView extends View {
 		drawTip(canvas, getTip(hasIcon));
 		drawIcon(canvas, iconAdd, iconAddRect, !hasIcon);
 		drawIcon(canvas, iconRemove, iconRemoveRect, hasIcon);
+		drawIcon(canvas, iconRotate, iconRotateRect, !hasIcon);
 		drawIcon(canvas, iconInfo, iconInfoRect, hasIcon);
 		drawIcon(canvas, iconDone, iconDoneRect, !hasIcon);
 		int centerX = viewWidth >> 1;

--- a/app/src/main/res/drawable/ic_rotation.xml
+++ b/app/src/main/res/drawable/ic_rotation.xml
@@ -1,0 +1,5 @@
+<vector android:height="64dp" android:tint="#FFFFFF"
+    android:viewportHeight="64" android:viewportWidth="64"
+    android:width="64dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:name="path" android:pathData="M 36.48 22.52 C 39.75 24.07 42.09 27.24 42.45 31 L 43.95 31 C 43.44 24.84 38.29 20 32 20 L 31.34 20.03 L 35.15 23.84 L 36.48 22.52 Z M 30.23 21.75 C 29.64 21.16 28.69 21.16 28.11 21.75 L 21.75 28.11 C 21.16 28.7 21.16 29.65 21.75 30.23 L 33.77 42.25 C 34.36 42.84 35.31 42.84 35.89 42.25 L 42.25 35.89 C 42.84 35.3 42.84 34.35 42.25 33.77 L 30.23 21.75 Z M 34.83 41.19 L 22.81 29.17 L 29.17 22.81 L 41.19 34.83 L 34.83 41.19 Z M 27.52 41.48 C 24.25 39.94 21.91 36.76 21.55 33 L 20.05 33 C 20.56 39.16 25.71 44 32 44 L 32.66 43.97 L 28.85 40.16 L 27.52 41.48 Z" android:fillColor="#ffffff"/>
+</vector>


### PR DESCRIPTION
A fix suggestion for issue #34 
Added a "Change Orientation" button in the pie edit menu. This button changes the orientation and remembers it for future startups.

![image](https://github.com/markusfisch/PieLauncher/assets/29482380/8b201df6-6915-42ba-b29e-0846cfd4e8ca)

### Design
My first iteration on the concept was a list of buttons, each representing a different orientation, which the user will be able to choose from (perhaps including auto-rotate and locked).
![image](https://github.com/markusfisch/PieLauncher/assets/29482380/21713e14-5319-4660-83e1-e0c680abf5f9)
After implementing this however, I noticed that I only ever had use for one of the buttons - the one to change my current orientation. Since the user can infer what their orientation is, and so there's no need to display it, I opted for this simpler one-button design.

I am not 100% fixed on this design, specifically because it changes the configuration menu's purpose (The previous purpose was simply to modify the pie menu, and it was tailored for it). I couldn't think of a different place to put the button that wouldn't hurt the app's simplistic UI, but would love to change it if you have any suggestions.
