### PR TITLE
Add german translation and options "search strictness" and "auto-launch only app matching search"

### DIFF
--- a/app/src/main/java/de/markusfisch/android/pielauncher/activity/HomeActivity.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/activity/HomeActivity.java
@@ -242,6 +242,9 @@ public class HomeActivity extends Activity {
 
 	private void updateAppList() {
 		pieView.filterAppList(searchInput.getText().toString());
+		if (pieView.getIconCount() == 1 && PieLauncherApp.getPrefs(this).autolaunchMatching()) {
+			pieView.launchFirstApp();
+		}
 	}
 
 	private static int fadeColor(int argb, float fraction) {

--- a/app/src/main/java/de/markusfisch/android/pielauncher/activity/HomeActivity.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/activity/HomeActivity.java
@@ -178,6 +178,15 @@ public class HomeActivity extends Activity {
 			@Override
 			public void afterTextChanged(Editable e) {
 				if (updateAfterTextChange) {
+					if (e.toString().endsWith("  ")) {
+						updateAfterTextChange = false;
+						String strippedQuery = e.toString().substring(0, e.toString().length() - 2);
+						e.clear();
+						e.append(strippedQuery);
+						updateAppList();
+						updateAfterTextChange = true;
+						pieView.launchFirstApp();
+					}
 					updateAppList();
 				}
 			}

--- a/app/src/main/java/de/markusfisch/android/pielauncher/activity/SettingsActivity.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/activity/SettingsActivity.java
@@ -10,7 +10,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.text.Html;
 import android.text.Spanned;
-import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
 

--- a/app/src/main/java/de/markusfisch/android/pielauncher/activity/SettingsActivity.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/activity/SettingsActivity.java
@@ -49,6 +49,8 @@ public class SettingsActivity extends Activity {
 		isWelcomeMode = intent != null &&
 				intent.getBooleanExtra(WELCOME, false);
 
+		findViewById(R.id.hide_in_welcome_mode).setVisibility(isWelcomeMode ? View.GONE : View.VISIBLE);
+
 		initHeadline();
 		initDisplayKeyboard();
 		initOrientation();
@@ -101,10 +103,6 @@ public class SettingsActivity extends Activity {
 
 	private void initDisplayKeyboard() {
 		TextView displayKeyboardView = findViewById(R.id.display_keyboard);
-		if (isWelcomeMode) {
-			displayKeyboardView.setVisibility(View.GONE);
-			return;
-		}
 		displayKeyboardView.setOnClickListener(v -> {
 			showOptionsDialog(
 					R.string.display_keyboard,
@@ -139,10 +137,6 @@ public class SettingsActivity extends Activity {
 
 	private void initOrientation() {
 		TextView orientationView = findViewById(R.id.orientation);
-		if (isWelcomeMode) {
-			orientationView.setVisibility(View.GONE);
-			return;
-		}
 		orientationView.setOnClickListener(v -> {
 			showOptionsDialog(
 					R.string.orientation,

--- a/app/src/main/java/de/markusfisch/android/pielauncher/activity/SettingsActivity.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/activity/SettingsActivity.java
@@ -10,6 +10,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.text.Html;
 import android.text.Spanned;
+import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
 
@@ -17,6 +18,7 @@ import de.markusfisch.android.pielauncher.R;
 import de.markusfisch.android.pielauncher.app.PieLauncherApp;
 import de.markusfisch.android.pielauncher.os.BatteryOptimization;
 import de.markusfisch.android.pielauncher.os.DefaultLauncher;
+import de.markusfisch.android.pielauncher.preference.Preferences;
 import de.markusfisch.android.pielauncher.view.SystemBars;
 
 public class SettingsActivity extends Activity {
@@ -53,6 +55,8 @@ public class SettingsActivity extends Activity {
 
 		initHeadline();
 		initDisplayKeyboard();
+		initSearchStrictness();
+		initAutolaunchMatching();
 		initOrientation();
 		initDoneButton();
 
@@ -133,6 +137,75 @@ public class SettingsActivity extends Activity {
 				PieLauncherApp.getPrefs(context).displayKeyboard()
 						? R.string.display_keyboard_yes
 						: R.string.display_keyboard_no));
+	}
+
+	private void initSearchStrictness() {
+		TextView searchStrictnessView = findViewById(R.id.search_strictness);
+		searchStrictnessView.setOnClickListener(v -> {
+			showOptionsDialog(
+					R.string.search_strictness,
+					R.array.search_strictness_names,
+					(view, which) -> {
+						Preferences.SearchStrictness searchStrictness;
+						switch (which) {
+							default:
+							case 0:
+								searchStrictness = Preferences.SearchStrictness.HAMMING;
+								break;
+							case 1:
+								searchStrictness = Preferences.SearchStrictness.CONTAINS;
+								break;
+							case 2:
+								searchStrictness = Preferences.SearchStrictness.STARTS_WITH;
+								break;
+						}
+						PieLauncherApp.getPrefs(this).setSearchStrictness(searchStrictness);
+						updateSearchStrictnessText(searchStrictnessView);
+					});
+		});
+		updateSearchStrictnessText(searchStrictnessView);
+	}
+
+	private static void updateSearchStrictnessText(TextView tv) {
+		Context context = tv.getContext();
+		tv.setText(getLabelAndValue(
+				context,
+				R.string.search_strictness,
+				PieLauncherApp.getPrefs(context).searchStrictness().getDescriptionText()));
+	}
+
+	private void initAutolaunchMatching() {
+		TextView autolaunchMatchingView = findViewById(R.id.autolaunch_matching);
+		autolaunchMatchingView.setOnClickListener(v -> {
+			showOptionsDialog(
+					R.string.autolaunch_matching,
+					R.array.autolaunch_matching_names,
+					(view, which) -> {
+						boolean autolauchMatching;
+						switch (which) {
+							default:
+							case 0:
+								autolauchMatching = true;
+								break;
+							case 1:
+								autolauchMatching = false;
+								break;
+						}
+						PieLauncherApp.getPrefs(this).setAutolaunchMatching(autolauchMatching);
+						updateAutolaunchMatchingText(autolaunchMatchingView);
+					});
+		});
+		updateAutolaunchMatchingText(autolaunchMatchingView);
+	}
+
+	private static void updateAutolaunchMatchingText(TextView tv) {
+		Context context = tv.getContext();
+		tv.setText(getLabelAndValue(
+				context,
+				R.string.autolaunch_matching,
+				PieLauncherApp.getPrefs(context).autolaunchMatching()
+						? R.string.autolaunch_matching_yes
+						: R.string.autolaunch_matching_no));
 	}
 
 	private void initOrientation() {

--- a/app/src/main/java/de/markusfisch/android/pielauncher/content/AppMenu.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/content/AppMenu.java
@@ -38,8 +38,10 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Executors;
 
+import de.markusfisch.android.pielauncher.app.PieLauncherApp;
 import de.markusfisch.android.pielauncher.graphics.CanvasPieMenu;
 import de.markusfisch.android.pielauncher.graphics.Converter;
+import de.markusfisch.android.pielauncher.preference.Preferences;
 
 public class AppMenu extends CanvasPieMenu {
 	public static class AppIcon extends CanvasPieMenu.CanvasIcon {
@@ -149,7 +151,7 @@ public class AppMenu extends CanvasPieMenu {
 		storeMenu(context, icons);
 	}
 
-	public List<AppIcon> filterAppsBy(String query) {
+	public List<AppIcon> filterAppsBy(Context context, String query) {
 		if (indexing) {
 			return null;
 		}
@@ -157,6 +159,8 @@ public class AppMenu extends CanvasPieMenu {
 			query = "";
 		}
 		query = query.trim().toLowerCase(Locale.getDefault());
+		Preferences.SearchStrictness searchStrictness = PieLauncherApp.getPrefs(context).searchStrictness();
+
 		ArrayList<AppIcon> list = new ArrayList<>();
 		ArrayList<AppIcon> contain = new ArrayList<>();
 		ArrayList<AppIcon> hamming = new ArrayList<>();
@@ -176,10 +180,15 @@ public class AppMenu extends CanvasPieMenu {
 			}
 		}
 		Collections.sort(list, appLabelComparator);
+		if (searchStrictness == Preferences.SearchStrictness.STARTS_WITH) return list;
+
 		Collections.sort(contain, appLabelComparator);
-		Collections.sort(hamming, appLabelComparator);
 		list.addAll(contain);
+		if (searchStrictness == Preferences.SearchStrictness.CONTAINS) return list;
+
+		Collections.sort(hamming, appLabelComparator);
 		list.addAll(hamming);
+
 		return list;
 	}
 

--- a/app/src/main/java/de/markusfisch/android/pielauncher/preference/Preferences.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/preference/Preferences.java
@@ -6,16 +6,21 @@ import android.content.pm.ActivityInfo;
 import android.preference.PreferenceManager;
 import android.util.DisplayMetrics;
 
+import de.markusfisch.android.pielauncher.R;
+
 public class Preferences {
 	private static final String SKIP_SETUP = "skip_setup";
 	private static final String RADIUS = "radius";
 	private static final String DISPLAY_KEYBOARD = "display_keyboard";
+	private static final String AUTOLAUNCH_MATCHING = "display_keyboard";
 	private static final String ORIENTATION = "orientation";
 
 	private final SharedPreferences preferences;
 
 	private boolean skipSetup = false;
 	private boolean displayKeyboard = true;
+	private SearchStrictness searchStrictness = SearchStrictness.HAMMING;
+	private boolean autolaunchMatching = false;
 	private int orientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
 
 	public Preferences(Context context) {
@@ -57,6 +62,23 @@ public class Preferences {
 		put(DISPLAY_KEYBOARD, displayKeyboard).apply();
 	}
 
+	public void setSearchStrictness(SearchStrictness searchStrictness) {
+		this.searchStrictness = searchStrictness;
+	}
+
+	public SearchStrictness searchStrictness() {
+		return searchStrictness;
+	}
+
+	public boolean autolaunchMatching() {
+		return autolaunchMatching;
+	}
+
+	public void setAutolaunchMatching(boolean autolaunchMatching) {
+		this.autolaunchMatching = autolaunchMatching;
+		put(AUTOLAUNCH_MATCHING, autolaunchMatching).apply();
+	}
+
 	public int getOrientation() {
 		return orientation;
 	}
@@ -82,5 +104,23 @@ public class Preferences {
 
 	private interface PutListener {
 		void put(SharedPreferences.Editor editor);
+	}
+
+	public enum SearchStrictness {
+		HAMMING,
+		CONTAINS,
+		STARTS_WITH;
+
+		public int getDescriptionText() {
+			switch (this) {
+				default:
+				case HAMMING:
+					return R.string.search_strictness_hamming;
+				case CONTAINS:
+					return R.string.search_strictness_contains;
+				case STARTS_WITH:
+					return R.string.search_strictness_starts_with;
+			}
+		}
 	}
 }

--- a/app/src/main/java/de/markusfisch/android/pielauncher/widget/AppPieView.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/widget/AppPieView.java
@@ -194,6 +194,11 @@ public class AppPieView extends View {
 		return appList == null || appList.size() < 1;
 	}
 
+	public int getIconCount() {
+		if (appList == null) return 0;
+		return appList.size();
+	}
+
 	public boolean isAppListScrolled() {
 		return mode == MODE_LIST && getScrollY() != 0;
 	}
@@ -208,7 +213,7 @@ public class AppPieView extends View {
 
 	public void filterAppList(String query) {
 		List<AppMenu.AppIcon> newAppList =
-				PieLauncherApp.appMenu.filterAppsBy(query);
+				PieLauncherApp.appMenu.filterAppsBy(getContext(), query);
 		if (newAppList != null) {
 			appList = newAppList;
 		}

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -14,7 +14,7 @@
 			android:id="@+id/headline"
 			android:drawableLeft="@drawable/ic_back"
 			android:drawableStart="@drawable/ic_back"
-			android:text="@string/settings"/>
+			android:text="@string/settings" />
 		<de.markusfisch.android.pielauncher.widget.PreferenceView
 			android:id="@+id/welcome"
 			android:drawablePadding="8dp"
@@ -27,28 +27,34 @@
 			android:textAppearance="@android:style/TextAppearance.Medium"
 			android:textColor="@color/text_color"
 			android:textStyle="bold"
-			android:text="@string/check_the_settings"/>
+			android:text="@string/check_the_settings" />
 		<de.markusfisch.android.pielauncher.widget.PreferenceView
 			style="@style/Preference"
 			android:id="@+id/disable_battery_optimization"
-			android:text="@string/disable_battery_optimization"/>
+			android:text="@string/disable_battery_optimization" />
 		<de.markusfisch.android.pielauncher.widget.PreferenceView
 			style="@style/Preference"
 			android:id="@+id/make_default_launcher"
-			android:text="@string/make_default_launcher"/>
-		<de.markusfisch.android.pielauncher.widget.PreferenceView
-			style="@style/Preference"
-			android:id="@+id/display_keyboard"
-			android:text="@string/display_keyboard_yes"/>
-		<de.markusfisch.android.pielauncher.widget.PreferenceView
-			style="@style/Preference"
-			android:id="@+id/orientation"
-			android:text="@string/orientation_portrait"/>
+			android:text="@string/make_default_launcher" />
+		<LinearLayout
+			android:id="@+id/hide_in_welcome_mode"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:orientation="vertical">
+			<de.markusfisch.android.pielauncher.widget.PreferenceView
+				style="@style/Preference"
+				android:id="@+id/display_keyboard"
+				android:text="@string/display_keyboard_yes" />
+			<de.markusfisch.android.pielauncher.widget.PreferenceView
+				style="@style/Preference"
+				android:id="@+id/orientation"
+				android:text="@string/orientation_portrait" />
+		</LinearLayout>
 		<Button
 			style="@style/Button"
 			android:id="@+id/done"
 			android:layout_gravity="center_horizontal"
 			android:layout_margin="16dp"
-			android:text="@string/ready"/>
+			android:text="@string/ready" />
 	</LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -47,6 +47,14 @@
 				android:text="@string/display_keyboard_yes" />
 			<de.markusfisch.android.pielauncher.widget.PreferenceView
 				style="@style/Preference"
+				android:id="@+id/search_strictness"
+				android:text="@string/search_strictness_hamming" />
+			<de.markusfisch.android.pielauncher.widget.PreferenceView
+				style="@style/Preference"
+				android:id="@+id/autolaunch_matching"
+				android:text="@string/autolaunch_matching_no" />
+			<de.markusfisch.android.pielauncher.widget.PreferenceView
+				style="@style/Preference"
 				android:id="@+id/orientation"
 				android:text="@string/orientation_portrait" />
 		</LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,24 @@
+<resources>
+	<string name="app_name">Pie Launcher</string>
+	<string name="tip_number_of_icons">Verwenden Sie 4, 6 oder 8 Symbole für das beste Erlebnis</string>
+	<string name="tip_pinch_zoom">Mit zwei Fingern die Größe einstellen</string>
+	<string name="tip_drag_to_order">Apps ziehen, um die Anordnung zu ändern</string>
+	<string name="settings">Einstellungen</string>
+	<string name="welcome">Willkommen!</string>
+	<string name="check_the_settings">Überprüfen Sie bitte die folgenden Einstellungen:</string>
+	<string name="disable_battery_optimization"><big>Akkuoptimierung für Pie Launcher deaktivieren</big>\nErlaubt es, den Startbildschirm immer bereitzuhalten</string>
+	<string name="make_default_launcher"><big>Zum Standard-Startbildschirm machen</big>\nÖffnet Pie Launcher anstelle des System-Stardbildschirms</string>
+	<string name="display_keyboard">Tastatur öffnen</string>
+	<string name="display_keyboard_yes">Mit der App-Liste automatisch die Tastatur öffnen</string>
+	<string name="display_keyboard_no">In der App-Liste die Tastatur geschlossen lassen</string>
+	<string name="orientation_portrait">Hochformat</string>
+	<string name="orientation_landscape">Querformat</string>
+	<string name="ready">Bereit</string>
+	<string name="search_strictness_hamming">Ähnelt Suchtext</string>
+	<string name="search_strictness_contains">Enthält Suchtext</string>
+	<string name="search_strictness_starts_with">Beginnt mit Suchtext</string>
+	<string name="autolaunch_matching_yes">Diese automatisch starten</string>
+	<string name="autolaunch_matching_no">Nicht automatisch starten</string>
+	<string name="search_strictness">Strenge bei der App-Suche</string>
+	<string name="autolaunch_matching">Wenn nur eine App der Suche entspricht:</string>
+</resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -11,6 +11,13 @@
 	<string name="display_keyboard">Clavier d\'affichage</string>
 	<string name="display_keyboard_yes">Afficher automatiquement le clavier dans la liste des applications</string>
 	<string name="display_keyboard_no">Ne pas afficher le clavier dans la liste des applications</string>
+	<string name="search_strictness">Rigueur dans le filtrage des applications</string>
+	<string name="search_strictness_hamming">Ressemble au texte de recherche</string>
+	<string name="search_strictness_contains">Contient le texte de recherche</string>
+	<string name="search_strictness_starts_with">Commence par le texte de recherche</string>
+	<string name="autolaunch_matching">Lors qu\'une seule application correspond à la recherche:</string>
+	<string name="autolaunch_matching_yes">La lancer automatiquement</string>
+	<string name="autolaunch_matching_no">Ne pas la lancer automatiquement</string>
 	<string name="orientation">Orientation</string>
 	<string name="orientation_portrait">Portrait</string>
 	<string name="orientation_landscape">Paysage</string>

--- a/app/src/main/res/values/settings.xml
+++ b/app/src/main/res/values/settings.xml
@@ -3,6 +3,15 @@
 		<item>@string/display_keyboard_yes</item>
 		<item>@string/display_keyboard_no</item>
 	</string-array>
+	<string-array name="search_strictness_names">
+		<item>@string/search_strictness_hamming</item>
+		<item>@string/search_strictness_contains</item>
+		<item>@string/search_strictness_starts_with</item>
+	</string-array>
+	<string-array name="autolaunch_matching_names">
+		<item>@string/autolaunch_matching_yes</item>
+		<item>@string/autolaunch_matching_no</item>
+	</string-array>
 	<string-array name="orientation_names">
 		<item>@string/orientation_portrait</item>
 		<item>@string/orientation_landscape</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,13 @@
 	<string name="display_keyboard">Display keyboard</string>
 	<string name="display_keyboard_yes">Automatically show keyboard in app list</string>
 	<string name="display_keyboard_no">Do not show the keyboard automatically</string>
+	<string name="search_strictness">Search strictness</string>
+	<string name="search_strictness_hamming">Resembles search text</string>
+	<string name="search_strictness_contains">Contains search text</string>
+	<string name="search_strictness_starts_with">Starts with search text</string>
+	<string name="autolaunch_matching">When only one app matches search:</string>
+	<string name="autolaunch_matching_yes">Auto-launch it</string>
+	<string name="autolaunch_matching_no">Don\'t auto-launch it</string>
 	<string name="orientation">Orientation</string>
 	<string name="orientation_portrait">Portrait</string>
 	<string name="orientation_landscape">Landscape</string>


### PR DESCRIPTION
## Search Strictness
- Let user choose how to filter the apps on the "all apps" screen
- Options are "resembles search text" (default; like before), "contains search text" and "starts with search text"

## Auto-launch only app matching search
- Option to directly launch an app as soon as it is the only one that matches the search filter

## Translations:
- Translated everything to german
- Newly added options are added to english, french, german, but not chinese

*thank you for having put an end to my search for a good launcher :)*