### PR TITLE
Add options menu for older phone with dedicated button

### DIFF
--- a/app/src/main/java/de/markusfisch/android/pielauncher/activity/HomeActivity.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/activity/HomeActivity.java
@@ -7,6 +7,8 @@ import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.GestureDetector;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewConfiguration;
@@ -82,6 +84,21 @@ public class HomeActivity extends Activity {
 						bottom));
 		SystemBars.setTransparentSystemBars(getWindow());
 	}
+
+  @Override
+  public boolean onCreateOptionsMenu(Menu menu) {
+    getMenuInflater().inflate(R.menu.home, menu);
+    return true;
+  }
+
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    if (item.getItemId() == R.id.settings)
+      SettingsActivity.start(this);
+    else
+      return super.onOptionsItemSelected(item);
+    return true;
+  }
 
 	@Override
 	protected void onNewIntent(Intent intent) {

--- a/app/src/main/res/menu/home.xml
+++ b/app/src/main/res/menu/home.xml
@@ -1,0 +1,4 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:id="@+id/settings"
+    android:title="@string/settings" android:icon="@android:drawable/ic_menu_preferences"/>
+</menu>


### PR DESCRIPTION
Demo:
![SC20231219-150149](https://github.com/markusfisch/PieLauncher/assets/70163032/a1475675-5efd-414d-ba74-11857ca45341)
In the screenshot you can see the added options menu opened by pressing the dedicated button. Currently there are no other actions than opening the settings because there is currently not much more it'd be really useful for considering the amount of effort for the implementation.
The motivation for this is to make some actions like the settings easier to access especially for phones with small screens.
For some more context see issue #64.