### PR TITLE
Add an option to search apps by package name

### DIFF
--- a/app/src/main/java/de/markusfisch/android/pielauncher/activity/PreferencesActivity.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/activity/PreferencesActivity.java
@@ -178,6 +178,11 @@ public class PreferencesActivity extends Activity {
 				PreferencesActivity::getSearchStrictnessOptions,
 				() -> prefs.getSearchStrictness(),
 				(value) -> prefs.setSearchStrictness(value));
+		initPreference(R.id.search_parameter,
+				R.string.search_parameter,
+				PreferencesActivity::getSearchParameterOptions,
+				() -> prefs.getSearchParameter(),
+				(value) -> prefs.setSearchParameter(value));
 		initPreference(R.id.show_app_names,
 				R.string.show_app_names,
 				PreferencesActivity::getShowAppNamesOptions,
@@ -396,6 +401,15 @@ public class PreferencesActivity extends Activity {
 				R.string.search_strictness_contains);
 		map.put(Preferences.SEARCH_STRICTNESS_STARTS_WITH,
 				R.string.search_strictness_starts_with);
+		return map;
+	}
+
+	private static Map<Integer, Integer> getSearchParameterOptions() {
+		Map<Integer, Integer> map = new LinkedHashMap<>();
+		map.put(Preferences.SEARCH_PARAMETER_APP_LABEL,
+				R.string.search_parameter_app_label);
+		map.put(Preferences.SEARCH_PARAMETER_PACKAGE_NAME,
+				R.string.search_parameter_package_name);
 		return map;
 	}
 

--- a/app/src/main/java/de/markusfisch/android/pielauncher/content/AppMenu.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/content/AppMenu.java
@@ -164,14 +164,22 @@ public class AppMenu extends CanvasPieMenu {
 		} else {
 			for (Map.Entry<LauncherItemKey, AppIcon> entry :
 					apps.entrySet()) {
+				String searchParameter;
 				AppIcon appIcon = entry.getValue();
-				String label = appIcon.label.toLowerCase(
-						Locale.getDefault());
-				if (label.startsWith(query)) {
+				int searchParameterPref = PieLauncherApp
+						.getPrefs(context).getSearchParameter();
+				if (searchParameterPref ==
+						Preferences.SEARCH_PARAMETER_PACKAGE_NAME) {
+					searchParameter = appIcon.componentName
+							.getPackageName().toLowerCase();
+				} else {
+					searchParameter = appIcon.label.toLowerCase();
+				}
+				if (searchParameter.startsWith(query)) {
 					list.add(appIcon);
-				} else if (label.contains(query)) {
+				} else if (searchParameter.contains(query)) {
 					contain.add(appIcon);
-				} else if (hammingDistance(label, query) < 2) {
+				} else if (hammingDistance(searchParameter, query) < 2) {
 					hamming.add(appIcon);
 				}
 			}

--- a/app/src/main/java/de/markusfisch/android/pielauncher/preference/Preferences.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/preference/Preferences.java
@@ -14,6 +14,8 @@ public class Preferences {
 	public static final int SEARCH_STRICTNESS_HAMMING = 1;
 	public static final int SEARCH_STRICTNESS_CONTAINS = 2;
 	public static final int SEARCH_STRICTNESS_STARTS_WITH = 3;
+	public static final int SEARCH_PARAMETER_APP_LABEL = 0;
+	public static final int SEARCH_PARAMETER_PACKAGE_NAME = 1;
 	public static final int SHOW_APP_NAMES_ALWAYS = 0;
 	public static final int SHOW_APP_NAMES_SEARCH = 1;
 	public static final int SHOW_APP_NAMES_NEVER = 2;
@@ -32,6 +34,7 @@ public class Preferences {
 	private static final String DOUBE_SPACE_LAUNCH = "space_action_double_launch";
 	private static final String AUTO_LAUNCH_MATCHING = "auto_launch_matching";
 	private static final String SEARCH_STRICTNESS = "strictness";
+	private static final String SEARCH_PARAMETER = "search_parameter";
 	private static final String SHOW_APP_NAMES = "show_app_names";
 	private static final String ICON_PRESS = "icon_press";
 	private static final String ICON_PACK = "icon_pack";
@@ -48,6 +51,7 @@ public class Preferences {
 	private boolean doubleSpaceLaunch = false;
 	private boolean autoLaunchMatching = false;
 	private int searchStrictness = SEARCH_STRICTNESS_HAMMING;
+	private int searchParameter = SEARCH_PARAMETER_APP_LABEL;
 	private int showAppNames = SHOW_APP_NAMES_ALWAYS;
 	private int iconPress = ICON_PRESS_DEFAULT;
 	private String iconPack;
@@ -76,6 +80,8 @@ public class Preferences {
 				autoLaunchMatching);
 		searchStrictness = preferences.getInt(SEARCH_STRICTNESS,
 				searchStrictness);
+		searchParameter = preferences.getInt(SEARCH_PARAMETER,
+				searchParameter);
 		showAppNames = preferences.getInt(SHOW_APP_NAMES, showAppNames);
 		iconPress = preferences.getInt(ICON_PRESS, iconPress);
 		iconPack = preferences.getString(ICON_PACK, iconPack);
@@ -168,6 +174,15 @@ public class Preferences {
 	public void setSearchStrictness(int searchStrictness) {
 		this.searchStrictness = searchStrictness;
 		put(SEARCH_STRICTNESS, searchStrictness).apply();
+	}
+
+	public int getSearchParameter() {
+		return searchParameter;
+	}
+
+	public void setSearchParameter(int searchParameter) {
+		this.searchParameter = searchParameter;
+		put(SEARCH_PARAMETER, searchParameter).apply();
 	}
 
 	public int showAppNames() {

--- a/app/src/main/res/layout/activity_preferences.xml
+++ b/app/src/main/res/layout/activity_preferences.xml
@@ -76,6 +76,10 @@
 					android:text="@string/search_strictness_hamming" />
 				<de.markusfisch.android.pielauncher.widget.PreferenceView
 					style="@style/PreferenceWithSeparator"
+					android:id="@+id/search_parameter"
+					android:text="@string/search_parameter_app_label" />
+				<de.markusfisch.android.pielauncher.widget.PreferenceView
+					style="@style/PreferenceWithSeparator"
 					android:id="@+id/show_app_names"
 					android:text="@string/show_app_names_always" />
 				<de.markusfisch.android.pielauncher.widget.PreferenceView

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -42,6 +42,9 @@
 	<string name="search_strictness_hamming">Name ähnelt dem Suchbegriff (Standard)</string>
 	<string name="search_strictness_contains">Name enthält Suchbegriff</string>
 	<string name="search_strictness_starts_with">Name beginnt mit Suchbegriff</string>
+	<string name="search_parameter">Suche nach</string>
+	<string name="search_parameter_app_label">App-Label (Standard)</string>
+	<string name="search_parameter_package_name">Paketnamen</string>
 	<string name="show_app_names">Zeige App-Namen</string>
 	<string name="show_app_names_always">Immer (Standard)</string>
 	<string name="show_app_names_search">Beim Suchen</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -42,6 +42,9 @@
 	<string name="search_strictness_hamming">Le nom ressemble au terme recherché (d\'usine)</string>
 	<string name="search_strictness_contains">Le nom contient le terme recherché</string>
 	<string name="search_strictness_starts_with">Le nom commence par le terme recherché</string>
+	<string name="search_parameter">Rechercher par</string>
+	<string name="search_parameter_app_label">Libellé d\'application (d\'usine)</string>
+	<string name="search_parameter_package_name">Nom de package</string>
 	<string name="show_app_names">Afficher les noms d\'app</string>
 	<string name="show_app_names_always">Toujours (d\'usine)</string>
 	<string name="show_app_names_search">Lors d\'une recherche</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -42,6 +42,9 @@
 	<string name="search_strictness_hamming">Вхождение схоже с запросом (Стандартно)</string>
 	<string name="search_strictness_contains">Вхождение содержит запрос</string>
 	<string name="search_strictness_starts_with">Вхождение начинается с запроса</string>
+	<string name="search_parameter">Поиск по</string>
+	<string name="search_parameter_app_label">Названию приложения (Стандартно)</string>
+	<string name="search_parameter_package_name">Названию пакета</string>
 	<string name="show_app_names">Показать названия приложений</string>
 	<string name="show_app_names_always">Всегда (Стандартно)</string>
 	<string name="show_app_names_search">При поиске</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -42,6 +42,9 @@
 	<string name="search_strictness_hamming">Назва схожа на пошуковий термін (за замовчуванням)</string>
 	<string name="search_strictness_contains">Назва містить пошуковий запит</string>
 	<string name="search_strictness_starts_with">Назва починається з пошукового терміну</string>
+	<string name="search_parameter">Пошук за</string>
+	<string name="search_parameter_app_label">Міткою програми (за замовчуванням)</string>
+	<string name="search_parameter_package_name">Назвою пакета</string>
 	<string name="show_app_names">Показати назви програм</string>
 	<string name="show_app_names_always">Завжди (за замовчуванням)</string>
 	<string name="show_app_names_search">Під час пошуку</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -42,6 +42,9 @@
 	<string name="search_strictness_hamming">名称与搜索词相似 (默认)</string>
 	<string name="search_strictness_contains">名称包含搜索词</string>
 	<string name="search_strictness_starts_with">名称以搜索词开头</string>
+	<string name="search_parameter">搜索参数</string>
+	<string name="search_parameter_app_label">应用标签 (默认)</string>
+	<string name="search_parameter_package_name">包裹名字</string>
 	<string name="show_app_names">显示应用程序名称</string>
 	<string name="show_app_names_always">始终如一 (默认)</string>
 	<string name="show_app_names_search">搜索时</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,9 @@
 	<string name="search_strictness_hamming">Name resembles search term (Default)</string>
 	<string name="search_strictness_contains">Name contains search term</string>
 	<string name="search_strictness_starts_with">Name starts with search term</string>
+	<string name="search_parameter">Search by</string>
+	<string name="search_parameter_app_label">App label (Default)</string>
+	<string name="search_parameter_package_name">Package name</string>
 	<string name="show_app_names">Show app names</string>
 	<string name="show_app_names_always">Always (Default)</string>
 	<string name="show_app_names_search">When searching</string>


### PR DESCRIPTION
This would help users with non-english system languages. For example, my system language is Kazakh and I have app labels such as "Күнтізбе" or "Параметрлер" that use cyrillic alphabet. The new feature would allow me to look up those apps with English keyboard.