### PR TITLE
Make parent style "Light"

### DIFF
--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 	<style
 		name="HomeTheme"
-		parent="android:Theme.Material.NoActionBar">
+		parent="@android:style/Theme.Material.Light.NoActionBar">
 		<item name="android:windowBackground">@android:color/transparent</item>
 		<item name="android:colorBackgroundCacheHint">@null</item>
 		<item name="android:windowShowWallpaper">true</item>


### PR DESCRIPTION
This makes the AlertDialogs on Oreo readable. (Before, there could be white text on white background.)