### PR TITLE
feat: Add option to hide app drawer

### DIFF
--- a/app/src/main/java/de/markusfisch/android/pielauncher/activity/HomeActivity.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/activity/HomeActivity.java
@@ -125,8 +125,7 @@ public class HomeActivity extends Activity {
 		// Because this activity has the launch mode "singleTask", it'll get
 		// an onNewIntent() when the activity is re-launched.
 		if (intent != null &&
-				(intent.getFlags() & Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT) !=
-						Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT) {
+				(intent.getFlags() & Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT) != Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT) {
 			// Deal with the gesture navigation/recent apps bug in Android 14:
 			// * make the home gesture twice
 			// * enter list of recent apps
@@ -178,6 +177,9 @@ public class HomeActivity extends Activity {
 			showAllAppsOnResume = false;
 		} else {
 			hideAllApps();
+		}
+		if (prefs.hideAppDrawer()) {
+			prefsButton.setVisibility(View.VISIBLE);
 		}
 	}
 
@@ -286,8 +288,8 @@ public class HomeActivity extends Activity {
 		boolean doubleSpaceLaunch = prefs.doubleSpaceLaunch();
 		String s = e.toString();
 		if ((doubleSpaceLaunch && s.endsWith("  ")) ||
-				// Some keyboards auto-replace two spaces with ". ",
-				// which means a new, different search result.
+		// Some keyboards auto-replace two spaces with ". ",
+		// which means a new, different search result.
 				s.endsWith(". ")) {
 			updateAfterTextChange = false;
 			e.clear();
@@ -341,13 +343,13 @@ public class HomeActivity extends Activity {
 	}
 
 	private void hidePrefsButton() {
-		if (prefsButton.getVisibility() == View.VISIBLE) {
+		if (!prefs.hideAppDrawer() && prefsButton.getVisibility() == View.VISIBLE) {
 			prefsButton.setVisibility(View.GONE);
 		}
 	}
 
 	private void showAllApps() {
-		if (isSearchVisible()) {
+		if (isSearchVisible() || prefs.hideAppDrawer()) {
 			return;
 		}
 

--- a/app/src/main/java/de/markusfisch/android/pielauncher/activity/PreferencesActivity.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/activity/PreferencesActivity.java
@@ -35,8 +35,7 @@ public class PreferencesActivity extends Activity {
 	private static final String WELCOME = "welcome";
 
 	private final Handler handler = new Handler(Looper.getMainLooper());
-	private final ExecutorService executor =
-			Executors.newSingleThreadExecutor();
+	private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
 	private Preferences prefs;
 	private ToolbarBackground toolbarBackground;
@@ -121,7 +120,7 @@ public class PreferencesActivity extends Activity {
 		boolean disableBatteryVisible = updateDisableBatteryOptimizations();
 		boolean updateDefaultVisible = updateDefaultLauncher();
 		if (disableBatteryVisible && updateDefaultVisible &&
-				// Auto close in welcome mode only.
+		// Auto close in welcome mode only.
 				isWelcomeMode) {
 			finish();
 		}
@@ -196,6 +195,11 @@ public class PreferencesActivity extends Activity {
 				PreferencesActivity::getHomeButtonOpensDrawerOptions,
 				() -> prefs.showDrawerOnHome(),
 				(value) -> prefs.setShowDrawerOnHome(value));
+		initPreference(R.id.hide_app_drawer,
+				R.string.hide_app_drawer,
+				PreferencesActivity::getHideAppDrawerOptions,
+				() -> prefs.hideAppDrawer(),
+				(value) -> prefs.setHideAppDrawer(value));
 		initPreference(R.id.open_list_with,
 				R.string.open_list_with,
 				PreferencesActivity::getOpenListWithOptions,
@@ -390,9 +394,8 @@ public class PreferencesActivity extends Activity {
 			disableBatteryOptimizations.setVisibility(View.GONE);
 			return true;
 		} else {
-			disableBatteryOptimizations.setOnClickListener(v ->
-					BatteryOptimization.requestDisable(
-							PreferencesActivity.this));
+			disableBatteryOptimizations.setOnClickListener(v -> BatteryOptimization.requestDisable(
+					PreferencesActivity.this));
 			return false;
 		}
 	}
@@ -402,8 +405,7 @@ public class PreferencesActivity extends Activity {
 			defaultLauncherView.setVisibility(View.GONE);
 			return true;
 		} else {
-			defaultLauncherView.setOnClickListener(v ->
-					DefaultLauncher.setAsDefault(this));
+			defaultLauncherView.setOnClickListener(v -> DefaultLauncher.setAsDefault(this));
 			return false;
 		}
 	}
@@ -481,6 +483,13 @@ public class PreferencesActivity extends Activity {
 		Map<Boolean, Integer> map = new LinkedHashMap<>();
 		map.put(Boolean.TRUE, R.string.home_button_opens_drawer_yes);
 		map.put(Boolean.FALSE, R.string.home_button_opens_drawer_no);
+		return map;
+	}
+
+	private static Map<Boolean, Integer> getHideAppDrawerOptions() {
+		Map<Boolean, Integer> map = new LinkedHashMap<>();
+		map.put(Boolean.TRUE, R.string.hide_app_drawer_yes);
+		map.put(Boolean.FALSE, R.string.hide_app_drawer_no);
 		return map;
 	}
 

--- a/app/src/main/java/de/markusfisch/android/pielauncher/preference/Preferences.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/preference/Preferences.java
@@ -71,6 +71,7 @@ public class Preferences {
 	private static final String USE_LIGHT_DIALOGS = "use_light_dialogs";
 	private static final String FORCE_RELAUNCH = "force_relaunch";
 	private static final String SHOW_DRAWER_ON_HOME = "show_drawer_on_home";
+	private static final String HIDE_APP_DRAWER = "hide_app_drawer";
 
 	private final SharedPreferences preferences;
 	private final SystemSettings systemSettings;
@@ -100,6 +101,7 @@ public class Preferences {
 	private boolean useLightDialogs = false;
 	private boolean forceRelaunch = false;
 	private boolean showDrawerOnHome = true;
+	private boolean hideAppDrawer = false;
 
 	public Preferences(Context context) {
 		preferences = PreferenceManager.getDefaultSharedPreferences(context);
@@ -150,6 +152,7 @@ public class Preferences {
 		forceRelaunch = preferences.getBoolean(FORCE_RELAUNCH, forceRelaunch);
 		showDrawerOnHome = preferences.getBoolean(SHOW_DRAWER_ON_HOME,
 				showDrawerOnHome);
+		hideAppDrawer = preferences.getBoolean(HIDE_APP_DRAWER, hideAppDrawer);
 	}
 
 	public boolean skipSetup() {
@@ -383,6 +386,15 @@ public class Preferences {
 	public void setShowDrawerOnHome(boolean showDrawerOnHome) {
 		this.showDrawerOnHome = showDrawerOnHome;
 		put(SHOW_DRAWER_ON_HOME, showDrawerOnHome).apply();
+	}
+
+	public boolean hideAppDrawer() {
+		return hideAppDrawer;
+	}
+
+	public void setHideAppDrawer(boolean hideAppDrawer) {
+		this.hideAppDrawer = hideAppDrawer;
+		put(HIDE_APP_DRAWER, hideAppDrawer).apply();
 	}
 
 	public float getAnimationDuration() {

--- a/app/src/main/java/de/markusfisch/android/pielauncher/widget/AppPieView.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/widget/AppPieView.java
@@ -55,18 +55,15 @@ public class AppPieView extends View {
 		void onDragDown(float alpha);
 	}
 
-	private static final int HAPTIC_FEEDBACK_DOWN =
-			Build.VERSION.SDK_INT < Build.VERSION_CODES.M
-					? HapticFeedbackConstants.KEYBOARD_TAP
-					: HapticFeedbackConstants.CONTEXT_CLICK;
-	private static final int HAPTIC_FEEDBACK_CONFIRM =
-			Build.VERSION.SDK_INT < Build.VERSION_CODES.R
-					? HAPTIC_FEEDBACK_DOWN
-					: HapticFeedbackConstants.CONFIRM;
-	private static final int HAPTIC_FEEDBACK_CHOICE =
-			Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE
-					? HAPTIC_FEEDBACK_DOWN
-					: HapticFeedbackConstants.SEGMENT_TICK;
+	private static final int HAPTIC_FEEDBACK_DOWN = Build.VERSION.SDK_INT < Build.VERSION_CODES.M
+			? HapticFeedbackConstants.KEYBOARD_TAP
+			: HapticFeedbackConstants.CONTEXT_CLICK;
+	private static final int HAPTIC_FEEDBACK_CONFIRM = Build.VERSION.SDK_INT < Build.VERSION_CODES.R
+			? HAPTIC_FEEDBACK_DOWN
+			: HapticFeedbackConstants.CONFIRM;
+	private static final int HAPTIC_FEEDBACK_CHOICE = Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+			? HAPTIC_FEEDBACK_DOWN
+			: HapticFeedbackConstants.SEGMENT_TICK;
 	private static final int MODE_PIE = 0;
 	private static final int MODE_LIST = 1;
 	private static final int MODE_EDIT = 2;
@@ -237,7 +234,8 @@ public class AppPieView extends View {
 		tapOrScrollTimeout = ViewConfiguration.getTapTimeout();
 		longPressTimeout = ViewConfiguration.getLongPressTimeout() *
 				(prefs.getIconPress() == Preferences.ICON_PRESS_LONGER
-						? 2L : 1L);
+						? 2L
+						: 1L);
 		doubleTapTimeout = ViewConfiguration.getDoubleTapTimeout();
 		if (PieLauncherApp.apps.isEmpty()) {
 			PieLauncherApp.apps.indexAppsAsync(context);
@@ -258,7 +256,7 @@ public class AppPieView extends View {
 	}
 
 	public void showList() {
-		if (mode == MODE_LIST) {
+		if (mode == MODE_LIST || prefs.hideAppDrawer()) {
 			return;
 		}
 		mode = MODE_LIST;
@@ -284,7 +282,7 @@ public class AppPieView extends View {
 	}
 
 	public void dragDownListBy(float y) {
-		if (mode != MODE_LIST) {
+		if (mode != MODE_LIST || prefs.hideAppDrawer()) {
 			return;
 		}
 		dragDistance -= y;
@@ -318,8 +316,7 @@ public class AppPieView extends View {
 	}
 
 	public void filterAppList(String query, boolean resetScroll) {
-		List<Apps.AppIcon> newAppList =
-				PieLauncherApp.apps.filterAppsBy(getContext(), query);
+		List<Apps.AppIcon> newAppList = PieLauncherApp.apps.filterAppsBy(getContext(), query);
 		if (newAppList != null) {
 			appList = newAppList;
 		}
@@ -384,8 +381,7 @@ public class AppPieView extends View {
 			}
 		}
 
-		if (mode != MODE_PIE || prefs.darkenBackground() !=
-				Preferences.DARKEN_BACKGROUND_NONE) {
+		if (mode != MODE_PIE || prefs.darkenBackground() != Preferences.DARKEN_BACKGROUND_NONE) {
 			darkenBackground(canvas, fMax);
 		}
 
@@ -424,8 +420,7 @@ public class AppPieView extends View {
 	private void initTouchListener() {
 		setOnTouchListener(new OnTouchListener() {
 			private final FlingRunnable flingRunnable = new FlingRunnable();
-			private final SparseArray<TouchReference> touchReferences =
-					new SparseArray<>();
+			private final SparseArray<TouchReference> touchReferences = new SparseArray<>();
 
 			private VelocityTracker velocityTracker;
 			private int primaryId;
@@ -896,8 +891,8 @@ public class AppPieView extends View {
 	}
 
 	private void layoutEditorControls(boolean portrait) {
-		Bitmap[] icons = new Bitmap[]{iconAdd, iconPreferences, iconDone};
-		Rect[] rects = new Rect[]{iconStartRect, iconCenterRect, iconEndRect};
+		Bitmap[] icons = new Bitmap[] { iconAdd, iconPreferences, iconDone };
+		Rect[] rects = new Rect[] { iconStartRect, iconCenterRect, iconEndRect };
 		int length = icons.length;
 		int totalWidth = 0;
 		int totalHeight = 0;
@@ -1083,8 +1078,7 @@ public class AppPieView extends View {
 				openList = wasTap || appIcon == null;
 				break;
 			case Preferences.OPEN_LIST_WITH_ICON:
-				result = openList =
-						PieLauncherApp.apps.isDrawerIcon(appIcon);
+				result = openList = PieLauncherApp.apps.isDrawerIcon(appIcon);
 				break;
 			case Preferences.OPEN_LIST_WITH_LONG_PRESS:
 				openList = wasLongPress;
@@ -1435,8 +1429,7 @@ public class AppPieView extends View {
 		int y = searchInputHeight + listPadding;
 
 		// Slide in/out animation.
-		if (prefs.listAnimationAppearance() ==
-				Preferences.LIST_APPEARANCE_ANIMATION_SLIDE ||
+		if (prefs.listAnimationAppearance() == Preferences.LIST_APPEARANCE_ANIMATION_SLIDE ||
 				isDraggingDownList()) {
 			y += Math.round((1f - f) * listFadeHeight);
 		}
@@ -1558,7 +1551,8 @@ public class AppPieView extends View {
 			}
 			drawAction(canvas, iconRemove, iconStartRect, radius);
 			drawAction(canvas, PieLauncherApp.iconPack.hasPacks()
-					? iconEdit : iconHide, iconCenterRect, radius);
+					? iconEdit
+					: iconHide, iconCenterRect, radius);
 			drawAction(canvas, iconDetails, iconEndRect, radius);
 		} else {
 			drawAction(canvas, iconChangeTwist, iconChangeTwistRect);
@@ -1667,7 +1661,8 @@ public class AppPieView extends View {
 			} else if (contains(iconCenterRect, touch)) {
 				setHighlightedAction(iconCenterRect);
 				return PieLauncherApp.iconPack.hasPacks()
-						? editAppTip : hideAppTip;
+						? editAppTip
+						: hideAppTip;
 			} else if (contains(iconEndRect, touch)) {
 				setHighlightedAction(iconEndRect);
 				return removeAppTip;
@@ -1753,8 +1748,7 @@ public class AppPieView extends View {
 	}
 
 	private boolean contains(Rect rect, Point point) {
-		return distSq(rect.centerX(), rect.centerY(), point.x, point.y) <
-				actionSizeSq;
+		return distSq(rect.centerX(), rect.centerY(), point.x, point.y) < actionSizeSq;
 	}
 
 	private static float distSq(int ax, int ay, int bx, int by) {
@@ -1804,8 +1798,7 @@ public class AppPieView extends View {
 
 	private void darkenBackground(Canvas canvas, float f) {
 		int max = (translucentBackgroundColor >> 24) & 0xff;
-		if (mode == MODE_PIE && prefs.darkenBackground() ==
-				Preferences.DARKEN_BACKGROUND_LIGHT) {
+		if (mode == MODE_PIE && prefs.darkenBackground() == Preferences.DARKEN_BACKGROUND_LIGHT) {
 			max /= 2;
 		}
 		int alpha = Math.round(f * max);

--- a/app/src/main/res/layout/activity_preferences.xml
+++ b/app/src/main/res/layout/activity_preferences.xml
@@ -76,6 +76,10 @@
 					android:text="@string/home_button_opens_drawer_yes" />
 				<de.markusfisch.android.pielauncher.widget.PreferenceView
 					style="@style/PreferenceWithSeparator"
+					android:id="@+id/hide_app_drawer"
+					android:text="@string/hide_app_drawer_no" />
+				<de.markusfisch.android.pielauncher.widget.PreferenceView
+					style="@style/PreferenceWithSeparator"
 					android:id="@+id/open_list_with"
 					android:text="@string/open_list_with_tap" />
 				<de.markusfisch.android.pielauncher.widget.PreferenceView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,9 @@
 	<string name="home_button_opens_drawer">Home button opens app drawer</string>
 	<string name="home_button_opens_drawer_yes">Yes (Default)</string>
 	<string name="home_button_opens_drawer_no">No</string>
+	<string name="hide_app_drawer">Hide app drawer</string>
+	<string name="hide_app_drawer_yes">Yes</string>
+	<string name="hide_app_drawer_no">No (Default)</string>
 	<string name="open_list_with">Opens with</string>
 	<string name="open_list_with_tap">A tap on the home screen (Default)</string>
 	<string name="open_list_with_any_touch">Any touch no matter how long</string>


### PR DESCRIPTION
This PR adds a **“Hide App Drawer”** preference aimed at reducing screen time and pushing more intentional app usage.

### Motivation

PieLauncher already does a great job at cutting down distractions. This builds on that idea by removing easy access to the full app list. When the app drawer is hidden, users can only launch apps they’ve deliberately pinned to the Pie Menu. That extra bit of friction helps break muscle-memory habits like doomscrolling or opening apps on autopilot.

### What’s changed

* Added a `hide_app_drawer` boolean preference.
* Exposed the setting as a toggle in **PreferencesActivity**.
* Updated **AppPieView** and **HomeActivity** to block opening the app drawer (both swipe and tap) when the option is enabled.
* **UI safeguard:** when the drawer is hidden, the Preferences button is permanently visible on the Home screen. This guarantees users can always get back into settings and turn the feature off if needed.

### Did i Tested the feature??

Yeah Im currently using this built on my android 14(xiaomi 11t pro) rn 

huge thanks for creating this launcher. I’ve been using PieLauncher for a while and genuinely love it. its best app for me for cutting down screen time.i feel grateful for contributing to this repo :) 