### PR TITLE
Handle OnBackInvokedCallback on Android 13+

### DIFF
--- a/app/src/main/java/de/markusfisch/android/pielauncher/activity/HomeActivity.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/activity/HomeActivity.java
@@ -17,6 +17,8 @@ import android.view.ViewConfiguration;
 import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
 import android.widget.ImageView;
+import android.window.OnBackInvokedCallback;
+import android.window.OnBackInvokedDispatcher;
 
 import de.markusfisch.android.pielauncher.R;
 import de.markusfisch.android.pielauncher.app.PieLauncherApp;
@@ -39,12 +41,15 @@ public class HomeActivity extends Activity {
 	private boolean showAllAppsOnResume = false;
 	private int immersiveMode = Preferences.IMMERSIVE_MODE_DISABLED;
 	private long pausedAt = 0L;
+	private OnBackInvokedCallback onBackInvokedCallback = null;
 
-	// I'm not including a support library to catch back presses.
-	// If this is no longer working on new Androids, so be it.
 	@SuppressLint("GestureBackNavigation")
 	@Override
 	public void onBackPressed() {
+		handleBack();
+	}
+
+	private void handleBack() {
 		if (pieView.inEditMode()) {
 			pieView.endEditMode();
 			showAllApps();
@@ -81,6 +86,7 @@ public class HomeActivity extends Activity {
 				ViewConfiguration.get(this).getScaledMinimumFlingVelocity()));
 
 		setContentView(R.layout.activity_home);
+		registerBackCallback();
 		if (!PreferencesActivity.isReady(this)) {
 			PreferencesActivity.startWelcome(this);
 		}
@@ -201,6 +207,7 @@ public class HomeActivity extends Activity {
 
 	@Override
 	protected void onDestroy() {
+		unregisterBackCallback();
 		PieLauncherApp.apps.setUpdateListener(null);
 		super.onDestroy();
 	}
@@ -417,6 +424,29 @@ public class HomeActivity extends Activity {
 
 	private void updateAppList(boolean resetScroll) {
 		pieView.filterAppList(searchInput.getText().toString(), resetScroll);
+	}
+
+	private void registerBackCallback() {
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+				onBackInvokedCallback != null) {
+			return;
+		}
+
+		onBackInvokedCallback = this::handleBack;
+		getOnBackInvokedDispatcher().registerOnBackInvokedCallback(
+				OnBackInvokedDispatcher.PRIORITY_DEFAULT,
+				onBackInvokedCallback);
+	}
+
+	private void unregisterBackCallback() {
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+				onBackInvokedCallback == null) {
+			return;
+		}
+
+		getOnBackInvokedDispatcher().unregisterOnBackInvokedCallback(
+				onBackInvokedCallback);
+		onBackInvokedCallback = null;
 	}
 
 	private class FlingListener extends GestureDetector.SimpleOnGestureListener {

--- a/app/src/main/java/de/markusfisch/android/pielauncher/activity/PreferencesActivity.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/activity/PreferencesActivity.java
@@ -13,6 +13,8 @@ import android.text.Spanned;
 import android.view.View;
 import android.view.Window;
 import android.widget.TextView;
+import android.window.OnBackInvokedCallback;
+import android.window.OnBackInvokedDispatcher;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -38,6 +40,8 @@ public class PreferencesActivity extends Activity {
 	private final ExecutorService executor =
 			Executors.newSingleThreadExecutor();
 
+	private OnBackInvokedCallback onBackInvokedCallback = null;
+
 	private Preferences prefs;
 	private ToolbarBackground toolbarBackground;
 	private View disableBatteryOptimizations;
@@ -61,6 +65,7 @@ public class PreferencesActivity extends Activity {
 	@Override
 	protected void onCreate(Bundle state) {
 		super.onCreate(state);
+		registerBackCallback();
 		setContentView(R.layout.activity_preferences);
 
 		prefs = PieLauncherApp.getPrefs(this);
@@ -137,7 +142,31 @@ public class PreferencesActivity extends Activity {
 	@Override
 	protected void onDestroy() {
 		super.onDestroy();
+		unregisterBackCallback();
 		executor.shutdownNow();
+	}
+
+	private void registerBackCallback() {
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+				onBackInvokedCallback != null) {
+			return;
+		}
+
+		onBackInvokedCallback = this::finish;
+		getOnBackInvokedDispatcher().registerOnBackInvokedCallback(
+				OnBackInvokedDispatcher.PRIORITY_DEFAULT,
+				onBackInvokedCallback);
+	}
+
+	private void unregisterBackCallback() {
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+				onBackInvokedCallback == null) {
+			return;
+		}
+
+		getOnBackInvokedDispatcher().unregisterOnBackInvokedCallback(
+				onBackInvokedCallback);
+		onBackInvokedCallback = null;
 	}
 
 	private void initPreferences() {


### PR DESCRIPTION
Fix smart recovery warning on MagicOS by handling Android 13+ Back callbacks

Pie Launcher currently handles back through Activity.onBackPressed(). On newer Android versions, the app also runs with the platform OnBackInvoked back-dispatch path enabled.

On MagicOS, pressing back button 4 times while Pie Launcher is the default home app triggers a system “Smart recovery” dialog saying that Pie Launcher caused a serious error but Pie Launcher doesn't crash. Logcat contains no AndroidRuntime exception and the crash buffer is empty.

Registering an OnBackInvokedCallback on Android 13+ prevents the issue.

I also tested the manifest opt-out android:enableOnBackInvokedCallback="false" which also fixes the issue but registering the callback is a better solution.

Tested on:
  -Honor Magic V3
  -Android 15
  -Gesture navigation
  -3 buttons navigation