### PR TITLE
Add support for launching pinned shortcuts (PWAs)

### DIFF
--- a/app/src/main/java/de/markusfisch/android/pielauncher/activity/HomeActivity.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/activity/HomeActivity.java
@@ -111,6 +111,10 @@ public class HomeActivity extends Activity {
 
 		immersiveMode = prefs.getImmersiveMode();
 		SystemBars.setTransparentSystemBars(getWindow(), immersiveMode);
+
+		// We may have been started with a request to pin a shortcut, e.g. when
+		// a browser adds a PWA to the home screen. No-op for regular launches.
+		PieLauncherApp.apps.acceptPinRequest(this, getIntent());
 	}
 
 	@Override
@@ -130,6 +134,13 @@ public class HomeActivity extends Activity {
 	@Override
 	protected void onNewIntent(Intent intent) {
 		super.onNewIntent(intent);
+		// A shortcut-pin request (e.g. adding a PWA from a browser) arrives
+		// here while the launcher is already running. Handle it and return so
+		// the home-gesture logic below doesn't act on this unrelated intent.
+		if (Apps.isPinItemRequest(intent)) {
+			PieLauncherApp.apps.acceptPinRequest(this, intent);
+			return;
+		}
 		// Because this activity has the launch mode "singleTask", it'll get
 		// an onNewIntent() when the activity is re-launched.
 		if (intent != null &&

--- a/app/src/main/java/de/markusfisch/android/pielauncher/content/AppLauncher.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/content/AppLauncher.java
@@ -11,6 +11,7 @@ import android.content.pm.LauncherUserInfo;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Process;
 import android.os.UserHandle;
 import android.os.UserManager;
 import android.provider.Settings;
@@ -50,13 +51,47 @@ public class AppLauncher {
 	}
 
 	public static boolean launchApp(Context context, AppIcon icon) {
+		if (Apps.isShortcut(icon)) {
+			return launchShortcut(context, icon);
+		}
 		if (HAS_LAUNCHER_APP) {
 			return launchAppWithLauncherApp(context, icon);
 		}
 		return launchPackage(context, icon.componentName.getPackageName());
 	}
 
+	@SuppressLint("UseRequiresApi")
+	@TargetApi(Build.VERSION_CODES.O)
+	private static boolean launchShortcut(Context context, AppIcon icon) {
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+			return false;
+		}
+		LauncherApps la = getLauncherApps(context);
+		if (la == null || icon.shortcutPackage == null) {
+			return false;
+		}
+		UserHandle user = icon.userHandle != null
+				? icon.userHandle
+				: Process.myUserHandle();
+		try {
+			la.startShortcut(icon.shortcutPackage, icon.shortcutId,
+					icon.rect, null, user);
+			return true;
+		} catch (Exception e) {
+			// e.g. IllegalStateException when this isn't the default launcher,
+			// or ActivityNotFoundException if the shortcut no longer exists.
+			toast(context, R.string.activity_not_enabled);
+			return false;
+		}
+	}
+
 	public static void launchAppInfo(Context context, AppIcon icon) {
+		if (Apps.isShortcut(icon)) {
+			// A pinned shortcut has no app-info page of its own; show the
+			// owning app (e.g. the browser that created the PWA) instead.
+			launchAppInfo(context, icon.shortcutPackage);
+			return;
+		}
 		if (HAS_LAUNCHER_APP) {
 			getLauncherApps(context).startAppDetailsActivity(
 					icon.componentName,

--- a/app/src/main/java/de/markusfisch/android/pielauncher/content/Apps.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/content/Apps.java
@@ -10,6 +10,7 @@ import android.content.pm.LauncherActivityInfo;
 import android.content.pm.LauncherApps;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.content.pm.ShortcutInfo;
 import android.graphics.Bitmap;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
@@ -18,6 +19,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.UserHandle;
 import android.os.UserManager;
+import android.util.Base64;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -55,6 +57,13 @@ public class Apps {
 		// after indexing (e.g. when switching icons).
 		public ComponentName componentName;
 
+		// Non-null when this icon is a pinned shortcut (e.g. a PWA added to
+		// the home screen from a browser) instead of an installed app. In
+		// that case the item is launched with LauncherApps.startShortcut()
+		// using these two values instead of starting a launcher activity.
+		public String shortcutId;
+		public String shortcutPackage;
+
 		AppIcon(ComponentName componentName, String label, Drawable icon,
 				UserHandle userHandle) {
 			super(Converter.getBitmapFromDrawable(icon));
@@ -78,6 +87,14 @@ public class Apps {
 
 	public static final String MENU_PRIMARY = "menu";
 	public static final String MENU_SECONDARY = "menu_alt";
+	// Synthetic package used for the ComponentName of pinned shortcuts so
+	// they flow through the same maps, menus and persistence as apps while
+	// never colliding with a real package (which would let a browser update
+	// wipe its shortcuts via the package-based add/remove paths).
+	public static final String SHORTCUT_PACKAGE =
+			"de.markusfisch.android.pielauncher.shortcut";
+	public static final String ACTION_CONFIRM_PIN_SHORTCUT =
+			"android.content.pm.action.CONFIRM_PIN_SHORTCUT";
 
 	public final ArrayList<AppIcon> menuPrimary = new ArrayList<>();
 	public final ArrayList<AppIcon> menuSecondary = new ArrayList<>();
@@ -125,6 +142,155 @@ public class Apps {
 		MenuStorage.store(context, MENU_PRIMARY, menuPrimary);
 		MenuStorage.store(context, MENU_SECONDARY, menuSecondary);
 		hiddenAppsStorage.store(context);
+	}
+
+	// --- Pinned shortcuts (e.g. PWAs added to the home screen) ------------
+
+	public static boolean isShortcut(AppIcon icon) {
+		return icon != null && icon.shortcutId != null;
+	}
+
+	public static boolean isPinItemRequest(Intent intent) {
+		return intent != null &&
+				ACTION_CONFIRM_PIN_SHORTCUT.equals(intent.getAction());
+	}
+
+	public static ComponentName shortcutComponentName(
+			String shortcutPackage, String shortcutId) {
+		// The class part only needs to be a stable, unique token per
+		// (owner, id); it's never decoded because both values are stored
+		// next to the icon. URL-safe Base64 avoids the '/' and '#' that
+		// ComponentName and LauncherItemKey use as separators.
+		String token = Base64.encodeToString(
+				(shortcutPackage + "\n" + shortcutId).getBytes(),
+				Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING);
+		return new ComponentName(SHORTCUT_PACKAGE, token);
+	}
+
+	// Handles the CONFIRM_PIN_SHORTCUT intent the system sends to the default
+	// launcher when an app (a browser adding a PWA, for instance) wants to pin
+	// a shortcut. Accepts the request, persists it and adds it to the drawer.
+	public void acceptPinRequest(Context context, Intent intent) {
+		// Keep the PinItemRequest reference out of this method so it can be
+		// safely invoked on pre-O devices without tripping class verification.
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+				isPinItemRequest(intent)) {
+			acceptPinRequestApi26(context, intent);
+		}
+	}
+
+	@SuppressLint("UseRequiresApi")
+	@TargetApi(Build.VERSION_CODES.O)
+	private void acceptPinRequestApi26(Context context, Intent intent) {
+		LauncherApps la = AppLauncher.getLauncherApps(context);
+		if (la == null) {
+			return;
+		}
+		LauncherApps.PinItemRequest request;
+		try {
+			request = la.getPinItemRequest(intent);
+		} catch (Exception e) {
+			return;
+		}
+		if (request == null ||
+				request.getRequestType() !=
+						LauncherApps.PinItemRequest.REQUEST_TYPE_SHORTCUT ||
+				!request.isValid()) {
+			return;
+		}
+		ShortcutInfo info = request.getShortcutInfo();
+		if (info == null) {
+			return;
+		}
+		AppIcon icon = buildShortcutIcon(context, la, info);
+		// Only accept the pin once we can actually represent it, so a request
+		// we can't render isn't silently accepted and then lost.
+		if (icon == null || !request.accept()) {
+			return;
+		}
+		// Persist first so the shortcut survives even if an index that is
+		// already running clears the map before the next one re-injects it.
+		PieLauncherApp.getDatabase(context).storePinnedShortcut(context, icon);
+		apps.put(new LauncherItemKey(icon.componentName, icon.userHandle),
+				icon);
+		if (isIndexing()) {
+			// Re-index once the running index finishes so the new shortcut
+			// isn't dropped by the map replacement at its end.
+			updateIconsAsync(context);
+		}
+		propagateUpdate();
+		AppLauncher.toast(context, context.getString(
+				R.string.added_to_home_screen, icon.label));
+	}
+
+	// Removes a pinned shortcut from the launcher completely.
+	public void removePinnedShortcut(Context context, AppIcon icon) {
+		if (!isShortcut(icon)) {
+			return;
+		}
+		PieLauncherApp.getDatabase(context).removePinnedShortcut(context, icon);
+		apps.remove(new LauncherItemKey(icon.componentName, icon.userHandle));
+		menuPrimary.remove(icon);
+		menuSecondary.remove(icon);
+		store(context);
+		propagateUpdate();
+		AppLauncher.toast(context, context.getString(
+				R.string.removed_from_home_screen, icon.label));
+	}
+
+	@SuppressLint("UseRequiresApi")
+	@TargetApi(Build.VERSION_CODES.O)
+	private static AppIcon buildShortcutIcon(Context context, LauncherApps la,
+			ShortcutInfo info) {
+		String shortcutPackage = info.getPackage();
+		String shortcutId = info.getId();
+		if (shortcutPackage == null || shortcutId == null) {
+			return null;
+		}
+		CharSequence label = info.getShortLabel();
+		if (label == null || label.length() < 1) {
+			label = info.getLongLabel();
+		}
+		if (label == null || label.length() < 1) {
+			label = shortcutPackage;
+		}
+		Drawable drawable = null;
+		try {
+			drawable = la.getShortcutIconDrawable(info,
+					context.getResources().getDisplayMetrics().densityDpi);
+		} catch (Exception e) {
+			// Fall through to the owning app's icon.
+		}
+		if (drawable == null) {
+			try {
+				drawable = context.getPackageManager()
+						.getApplicationIcon(shortcutPackage);
+			} catch (PackageManager.NameNotFoundException e) {
+				return null;
+			}
+		}
+		Bitmap bitmap = Converter.getBitmapFromDrawable(drawable);
+		if (bitmap == null) {
+			return null;
+		}
+		AppIcon icon = new AppIcon(
+				shortcutComponentName(shortcutPackage, shortcutId),
+				label.toString(),
+				bitmap,
+				info.getUserHandle());
+		icon.shortcutPackage = shortcutPackage;
+		icon.shortcutId = shortcutId;
+		return icon;
+	}
+
+	private void injectPinnedShortcuts(Context context,
+			Map<LauncherItemKey, AppIcon> allApps,
+			Set<ComponentName> hideApps) {
+		PieLauncherApp.getDatabase(context).restorePinnedShortcuts(
+				context, allApps);
+		if (hideApps != null) {
+			removeApps(allApps, hideApps);
+		}
 	}
 
 	public void removePackageAsync(Context context, String packageName,
@@ -215,6 +381,7 @@ public class Apps {
 					userRestriction,
 					hideApps,
 					newApps);
+			injectPinnedShortcuts(context, newApps, hideApps);
 			int reconciliation = reconcileChangedPackage(
 					newApps, oldPackageApps, packageRestriction, userRestriction);
 			Database database = PieLauncherApp.getDatabase(context);
@@ -315,6 +482,7 @@ public class Apps {
 			HashSet<ComponentName> hideApps) {
 		Map<LauncherItemKey, AppIcon> cachedApps = new HashMap<>();
 		PieLauncherApp.getDatabase(context).restoreApps(context, cachedApps);
+		injectPinnedShortcuts(context, cachedApps, null);
 		if (cachedApps.isEmpty()) {
 			return;
 		}

--- a/app/src/main/java/de/markusfisch/android/pielauncher/content/Database.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/content/Database.java
@@ -46,6 +46,10 @@ public class Database {
 
 	private static final String HIDDEN_APPS = "hidden_apps";
 
+	private static final String PINNED_SHORTCUTS = "pinned_shortcuts";
+	private static final String OWNER_PACKAGE = "owner_package";
+	private static final String SHORTCUT_ID = "shortcut_id";
+
 	private static final String ICON_MAPPING_SETS = "icon_mapping_sets";
 	private static final String ICON_MAPPINGS = "icon_mappings";
 	private static final String ICON_PACK = "icon_pack";
@@ -148,6 +152,82 @@ public class Database {
 			db.setTransactionSuccessful();
 		} finally {
 			db.endTransaction();
+		}
+	}
+
+	public void restorePinnedShortcuts(Context context,
+			Map<LauncherItemKey, Apps.AppIcon> apps) {
+		Cursor cursor = openHelper.getReadableDatabase().query(PINNED_SHORTCUTS,
+				new String[]{COMPONENT_NAME, USER_SERIAL, OWNER_PACKAGE,
+						SHORTCUT_ID, LABEL, ICON},
+				null, null, null, null, null);
+		try {
+			while (cursor.moveToNext()) {
+				ComponentName componentName =
+						ComponentName.unflattenFromString(cursor.getString(0));
+				String ownerPackage = cursor.getString(2);
+				String shortcutId = cursor.getString(3);
+				String label = cursor.getString(4);
+				byte[] icon = cursor.getBlob(5);
+				if (componentName == null || ownerPackage == null ||
+						shortcutId == null || label == null || icon == null) {
+					continue;
+				}
+				Bitmap bitmap = BitmapFactory.decodeByteArray(
+						icon, 0, icon.length);
+				if (bitmap == null) {
+					continue;
+				}
+				UserHandle userHandle = null;
+				long serialNumber = cursor.getLong(1);
+				if (AppLauncher.HAS_LAUNCHER_APP && serialNumber != NO_USER) {
+					userHandle = getUserForSerialNumber(context, serialNumber);
+					if (userHandle == null) {
+						continue;
+					}
+				}
+				Apps.AppIcon appIcon = new Apps.AppIcon(
+						componentName, label, bitmap, userHandle);
+				appIcon.shortcutPackage = ownerPackage;
+				appIcon.shortcutId = shortcutId;
+				apps.put(new LauncherItemKey(componentName, userHandle),
+						appIcon);
+			}
+		} finally {
+			cursor.close();
+		}
+	}
+
+	public void storePinnedShortcut(Context context, Apps.AppIcon appIcon) {
+		byte[] icon = getIconBlob(appIcon);
+		if (icon == null) {
+			return;
+		}
+		ContentValues values = new ContentValues();
+		values.put(COMPONENT_NAME, appIcon.componentName.flattenToString());
+		putUserSerial(context, values, appIcon.userHandle);
+		values.put(OWNER_PACKAGE, appIcon.shortcutPackage);
+		values.put(SHORTCUT_ID, appIcon.shortcutId);
+		values.put(LABEL, appIcon.label);
+		values.put(ICON, icon);
+		openHelper.getWritableDatabase().insertWithOnConflict(
+				PINNED_SHORTCUTS, null, values,
+				SQLiteDatabase.CONFLICT_REPLACE);
+	}
+
+	public void removePinnedShortcut(Context context, Apps.AppIcon appIcon) {
+		SQLiteDatabase db = openHelper.getWritableDatabase();
+		if (AppLauncher.HAS_LAUNCHER_APP && appIcon.userHandle != null) {
+			db.delete(PINNED_SHORTCUTS,
+					COMPONENT_NAME + "=? AND " + USER_SERIAL + "=?",
+					new String[]{
+							appIcon.componentName.flattenToString(),
+							String.valueOf(getSerialNumberForUser(
+									context, appIcon.userHandle))
+					});
+		} else {
+			db.delete(PINNED_SHORTCUTS, COMPONENT_NAME + "=?",
+					new String[]{appIcon.componentName.flattenToString()});
 		}
 	}
 
@@ -511,6 +591,12 @@ public class Database {
 			Map<LauncherItemKey, Apps.AppIcon> apps) {
 		long now = System.currentTimeMillis();
 		for (Apps.AppIcon appIcon : apps.values()) {
+			// Pinned shortcuts share the apps map but are persisted in their
+			// own table, so keep them out of the app cache.
+			if (Apps.SHORTCUT_PACKAGE.equals(
+					appIcon.componentName.getPackageName())) {
+				continue;
+			}
 			byte[] icon = getIconBlob(appIcon);
 			if (icon == null) {
 				continue;
@@ -603,7 +689,7 @@ public class Database {
 
 	private static class OpenHelper extends SQLiteOpenHelper {
 		OpenHelper(Context context) {
-			super(context, "app_cache.db", null, 3);
+			super(context, "app_cache.db", null, 4);
 		}
 
 		@Override
@@ -611,6 +697,7 @@ public class Database {
 			createAppsTables(db);
 			createStorageTables(db);
 			createUsageTables(db);
+			createShortcutsTable(db);
 		}
 
 		private static void createAppsTables(SQLiteDatabase db) {
@@ -662,6 +749,18 @@ public class Database {
 					APP_USAGE + " (" + PACKAGE_NAME + ");");
 		}
 
+		private static void createShortcutsTable(SQLiteDatabase db) {
+			db.execSQL("CREATE TABLE " + PINNED_SHORTCUTS + " (" +
+					COMPONENT_NAME + " TEXT NOT NULL," +
+					USER_SERIAL + " INTEGER NOT NULL," +
+					OWNER_PACKAGE + " TEXT NOT NULL," +
+					SHORTCUT_ID + " TEXT NOT NULL," +
+					LABEL + " TEXT NOT NULL," +
+					ICON + " BLOB NOT NULL," +
+					"PRIMARY KEY (" + COMPONENT_NAME + "," +
+					USER_SERIAL + "));");
+		}
+
 		@Override
 		public void onUpgrade(SQLiteDatabase db,
 				int oldVersion,
@@ -671,6 +770,9 @@ public class Database {
 			}
 			if (oldVersion < 3) {
 				createUsageTables(db);
+			}
+			if (oldVersion < 4) {
+				createShortcutsTable(db);
 			}
 		}
 

--- a/app/src/main/java/de/markusfisch/android/pielauncher/widget/AppPieView.java
+++ b/app/src/main/java/de/markusfisch/android/pielauncher/widget/AppPieView.java
@@ -1315,6 +1315,16 @@ public class AppPieView extends View {
 				if (PieLauncherApp.apps.isDrawerIcon(
 						(Apps.AppIcon) grabbedIcon)) {
 					removeIconFromPie(grabbedIcon, true);
+				} else if (Apps.isShortcut((Apps.AppIcon) grabbedIcon)) {
+					// The end target uninstalls apps; a pinned shortcut (e.g.
+					// a PWA) has nothing to uninstall, so remove it instead.
+					// Unlike launchAppInfo() this stays in-app, so we must end
+					// edit mode ourselves — otherwise the view is left in
+					// MODE_EDIT and the pie won't open until the activity is
+					// recreated (e.g. by pressing Home).
+					PieLauncherApp.apps.removePinnedShortcut(context,
+							(Apps.AppIcon) grabbedIcon);
+					endEditMode();
 				} else {
 					// Persist changes before launching app info because
 					// that can be used to uninstall an app which would

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,4 +130,6 @@
 	<string name="app_icon">App icon</string>
 	<string name="user_profile_locked">User profile locked</string>
 	<string name="activity_not_enabled">Activity not enabled\n</string>
+	<string name="added_to_home_screen">Added %1$s</string>
+	<string name="removed_from_home_screen">Removed %1$s</string>
 </resources>


### PR DESCRIPTION
Browsers pin a shortcut (via ShortcutManager.requestPinShortcut) when you "Add to Home screen" for a site they can't package as a WebAPK -- self-hosted pages, Firefox, or devices without Play Services. HomeActivity already declared the CONFIRM_PIN_SHORTCUT intent filter, but nothing handled the request, so the pinned shortcut was silently dropped.

Handle it and treat a pinned shortcut as a first-class launcher item:

- Represent it as an AppIcon with a synthetic ComponentName plus shortcutPackage/shortcutId, so it flows through the existing app map, drawer, search, pie menu and menu persistence unchanged.
- Launch via LauncherApps.startShortcut() from the single dispatch point in AppLauncher.launchApp().
- Persist in a new pinned_shortcuts table (db version 4) and re-inject on every index so shortcuts survive reindexing and reboots.
- Accept the request in HomeActivity (onCreate and onNewIntent), auto-adding with a toast.
- Remove a shortcut by dragging it onto the pie editor's uninstall target (ending edit mode cleanly); "Show app info" opens the owning app instead.